### PR TITLE
Lps 54096 - ldap type not selected properly

### DIFF
--- a/portal-impl/src/com/liferay/portal/model/ModelHintsImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/ModelHintsImpl.java
@@ -428,6 +428,9 @@ public class ModelHintsImpl implements ModelHints {
 					String validatorValue = GetterUtil.getString(
 						validatorElement.getText());
 					boolean customValidator = isCustomValidator(validatorName);
+					boolean customValidatorRequired = GetterUtil.getBoolean(
+						validatorElement.attributeValue(
+							"customValidatorRequired"));
 
 					if (customValidator) {
 						validatorName = buildCustomValidatorName(validatorName);
@@ -435,7 +438,8 @@ public class ModelHintsImpl implements ModelHints {
 
 					Tuple fieldValidator = new Tuple(
 						fieldName, validatorName, validatorErrorMessage,
-						validatorValue, customValidator);
+						validatorValue, customValidator,
+						customValidatorRequired);
 
 					fieldValidators.put(validatorName, fieldValidator);
 				}

--- a/portal-impl/src/com/liferay/portlet/PortletURLImpl.java
+++ b/portal-impl/src/com/liferay/portlet/PortletURLImpl.java
@@ -845,6 +845,15 @@ public class PortletURLImpl
 		ThemeDisplay themeDisplay = (ThemeDisplay)_request.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
+		if (themeDisplay == null) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to generate string because theme display is null");
+			}
+
+			return StringPool.BLANK;
+		}
+
 		String portalURL = null;
 
 		if (themeDisplay.isFacebook()) {

--- a/portal-impl/src/com/liferay/portlet/messageboards/service/http/MBMessageServiceHttp.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/service/http/MBMessageServiceHttp.java
@@ -142,6 +142,51 @@ public class MBMessageServiceHttp {
 	public static com.liferay.portlet.messageboards.model.MBMessage addMessage(
 		HttpPrincipal httpPrincipal, long groupId, long categoryId,
 		java.lang.String subject, java.lang.String body,
+		java.lang.String fileName, java.io.File file,
+		com.liferay.portal.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException,
+			java.io.FileNotFoundException {
+		try {
+			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
+					"addMessage", _addMessageParameterTypes2);
+
+			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
+					categoryId, subject, body, fileName, file, serviceContext);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				if (e instanceof com.liferay.portal.kernel.exception.PortalException) {
+					throw (com.liferay.portal.kernel.exception.PortalException)e;
+				}
+
+				if (e instanceof com.liferay.portal.kernel.exception.SystemException) {
+					throw (com.liferay.portal.kernel.exception.SystemException)e;
+				}
+
+				if (e instanceof java.io.FileNotFoundException) {
+					throw (java.io.FileNotFoundException)e;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(e);
+			}
+
+			return (com.liferay.portlet.messageboards.model.MBMessage)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
+	public static com.liferay.portlet.messageboards.model.MBMessage addMessage(
+		HttpPrincipal httpPrincipal, long groupId, long categoryId,
+		java.lang.String subject, java.lang.String body,
 		java.lang.String format,
 		java.util.List<com.liferay.portal.kernel.util.ObjectValuePair<java.lang.String, java.io.InputStream>> inputStreamOVPs,
 		boolean anonymous, double priority, boolean allowPingbacks,
@@ -150,7 +195,7 @@ public class MBMessageServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
-					"addMessage", _addMessageParameterTypes2);
+					"addMessage", _addMessageParameterTypes3);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					categoryId, subject, body, format, inputStreamOVPs,
@@ -183,6 +228,53 @@ public class MBMessageServiceHttp {
 	}
 
 	public static com.liferay.portlet.messageboards.model.MBMessage addMessage(
+		HttpPrincipal httpPrincipal, long groupId, long categoryId,
+		java.lang.String subject, java.lang.String body,
+		java.lang.String format, java.lang.String fileName, java.io.File file,
+		boolean anonymous, double priority, boolean allowPingbacks,
+		com.liferay.portal.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException,
+			java.io.FileNotFoundException {
+		try {
+			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
+					"addMessage", _addMessageParameterTypes4);
+
+			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
+					categoryId, subject, body, format, fileName, file,
+					anonymous, priority, allowPingbacks, serviceContext);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				if (e instanceof com.liferay.portal.kernel.exception.PortalException) {
+					throw (com.liferay.portal.kernel.exception.PortalException)e;
+				}
+
+				if (e instanceof com.liferay.portal.kernel.exception.SystemException) {
+					throw (com.liferay.portal.kernel.exception.SystemException)e;
+				}
+
+				if (e instanceof java.io.FileNotFoundException) {
+					throw (java.io.FileNotFoundException)e;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(e);
+			}
+
+			return (com.liferay.portlet.messageboards.model.MBMessage)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
+	public static com.liferay.portlet.messageboards.model.MBMessage addMessage(
 		HttpPrincipal httpPrincipal, long categoryId, java.lang.String subject,
 		java.lang.String body,
 		com.liferay.portal.service.ServiceContext serviceContext)
@@ -190,7 +282,7 @@ public class MBMessageServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
-					"addMessage", _addMessageParameterTypes3);
+					"addMessage", _addMessageParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					categoryId, subject, body, serviceContext);
@@ -232,7 +324,7 @@ public class MBMessageServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
-					"addMessage", _addMessageParameterTypes4);
+					"addMessage", _addMessageParameterTypes6);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					parentMessageId, subject, body, format, inputStreamOVPs,
@@ -273,7 +365,7 @@ public class MBMessageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
 					"deleteDiscussionMessage",
-					_deleteDiscussionMessageParameterTypes5);
+					_deleteDiscussionMessageParameterTypes7);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					className, classPK, permissionClassName, permissionClassPK,
@@ -306,7 +398,7 @@ public class MBMessageServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
-					"deleteMessage", _deleteMessageParameterTypes6);
+					"deleteMessage", _deleteMessageParameterTypes8);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, messageId);
 
@@ -339,7 +431,7 @@ public class MBMessageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
 					"deleteMessageAttachments",
-					_deleteMessageAttachmentsParameterTypes7);
+					_deleteMessageAttachmentsParameterTypes9);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, messageId);
 
@@ -372,7 +464,7 @@ public class MBMessageServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
-					"getCategoryMessages", _getCategoryMessagesParameterTypes8);
+					"getCategoryMessages", _getCategoryMessagesParameterTypes10);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					categoryId, status, start, end);
@@ -409,7 +501,7 @@ public class MBMessageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
 					"getCategoryMessagesCount",
-					_getCategoryMessagesCountParameterTypes9);
+					_getCategoryMessagesCountParameterTypes11);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					categoryId, status);
@@ -447,7 +539,7 @@ public class MBMessageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
 					"getCategoryMessagesRSS",
-					_getCategoryMessagesRSSParameterTypes10);
+					_getCategoryMessagesRSSParameterTypes12);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					categoryId, status, max, type, version, displayStyle,
@@ -489,7 +581,7 @@ public class MBMessageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
 					"getCompanyMessagesRSS",
-					_getCompanyMessagesRSSParameterTypes11);
+					_getCompanyMessagesRSSParameterTypes13);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					companyId, status, max, type, version, displayStyle,
@@ -527,7 +619,7 @@ public class MBMessageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
 					"getGroupMessagesCount",
-					_getGroupMessagesCountParameterTypes12);
+					_getGroupMessagesCountParameterTypes14);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					status);
@@ -563,7 +655,7 @@ public class MBMessageServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
-					"getGroupMessagesRSS", _getGroupMessagesRSSParameterTypes13);
+					"getGroupMessagesRSS", _getGroupMessagesRSSParameterTypes15);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					status, max, type, version, displayStyle, feedURL,
@@ -605,7 +697,7 @@ public class MBMessageServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
-					"getGroupMessagesRSS", _getGroupMessagesRSSParameterTypes14);
+					"getGroupMessagesRSS", _getGroupMessagesRSSParameterTypes16);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					userId, status, max, type, version, displayStyle, feedURL,
@@ -643,7 +735,7 @@ public class MBMessageServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
-					"getMessage", _getMessageParameterTypes15);
+					"getMessage", _getMessageParameterTypes17);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, messageId);
 
@@ -680,7 +772,7 @@ public class MBMessageServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
-					"getMessageDisplay", _getMessageDisplayParameterTypes16);
+					"getMessageDisplay", _getMessageDisplayParameterTypes18);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					messageId, status, threadView, includePrevAndNext);
@@ -717,7 +809,7 @@ public class MBMessageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
 					"getThreadAnswersCount",
-					_getThreadAnswersCountParameterTypes17);
+					_getThreadAnswersCountParameterTypes19);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					categoryId, threadId);
@@ -750,7 +842,7 @@ public class MBMessageServiceHttp {
 		throws com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
-					"getThreadMessages", _getThreadMessagesParameterTypes18);
+					"getThreadMessages", _getThreadMessagesParameterTypes20);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					categoryId, threadId, status, start, end);
@@ -783,7 +875,7 @@ public class MBMessageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
 					"getThreadMessagesCount",
-					_getThreadMessagesCountParameterTypes19);
+					_getThreadMessagesCountParameterTypes21);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					categoryId, threadId, status);
@@ -820,7 +912,7 @@ public class MBMessageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
 					"getThreadMessagesRSS",
-					_getThreadMessagesRSSParameterTypes20);
+					_getThreadMessagesRSSParameterTypes22);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					threadId, status, max, type, version, displayStyle,
@@ -859,7 +951,7 @@ public class MBMessageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
 					"restoreMessageAttachmentFromTrash",
-					_restoreMessageAttachmentFromTrashParameterTypes21);
+					_restoreMessageAttachmentFromTrashParameterTypes23);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					messageId, fileName);
@@ -892,7 +984,7 @@ public class MBMessageServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
-					"subscribeMessage", _subscribeMessageParameterTypes22);
+					"subscribeMessage", _subscribeMessageParameterTypes24);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, messageId);
 
@@ -924,7 +1016,7 @@ public class MBMessageServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
-					"unsubscribeMessage", _unsubscribeMessageParameterTypes23);
+					"unsubscribeMessage", _unsubscribeMessageParameterTypes25);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, messageId);
 
@@ -956,7 +1048,7 @@ public class MBMessageServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
-					"updateAnswer", _updateAnswerParameterTypes24);
+					"updateAnswer", _updateAnswerParameterTypes26);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					messageId, answer, cascade);
@@ -994,7 +1086,7 @@ public class MBMessageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
 					"updateDiscussionMessage",
-					_updateDiscussionMessageParameterTypes25);
+					_updateDiscussionMessageParameterTypes27);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					className, classPK, permissionClassName, permissionClassPK,
@@ -1037,7 +1129,7 @@ public class MBMessageServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
-					"updateMessage", _updateMessageParameterTypes26);
+					"updateMessage", _updateMessageParameterTypes28);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					messageId, subject, body, inputStreamOVPs, existingFiles,
@@ -1085,97 +1177,109 @@ public class MBMessageServiceHttp {
 		};
 	private static final Class<?>[] _addMessageParameterTypes2 = new Class[] {
 			long.class, long.class, java.lang.String.class,
+			java.lang.String.class, java.lang.String.class, java.io.File.class,
+			com.liferay.portal.service.ServiceContext.class
+		};
+	private static final Class<?>[] _addMessageParameterTypes3 = new Class[] {
+			long.class, long.class, java.lang.String.class,
 			java.lang.String.class, java.lang.String.class, java.util.List.class,
 			boolean.class, double.class, boolean.class,
 			com.liferay.portal.service.ServiceContext.class
 		};
-	private static final Class<?>[] _addMessageParameterTypes3 = new Class[] {
+	private static final Class<?>[] _addMessageParameterTypes4 = new Class[] {
+			long.class, long.class, java.lang.String.class,
+			java.lang.String.class, java.lang.String.class,
+			java.lang.String.class, java.io.File.class, boolean.class,
+			double.class, boolean.class,
+			com.liferay.portal.service.ServiceContext.class
+		};
+	private static final Class<?>[] _addMessageParameterTypes5 = new Class[] {
 			long.class, java.lang.String.class, java.lang.String.class,
 			com.liferay.portal.service.ServiceContext.class
 		};
-	private static final Class<?>[] _addMessageParameterTypes4 = new Class[] {
+	private static final Class<?>[] _addMessageParameterTypes6 = new Class[] {
 			long.class, java.lang.String.class, java.lang.String.class,
 			java.lang.String.class, java.util.List.class, boolean.class,
 			double.class, boolean.class,
 			com.liferay.portal.service.ServiceContext.class
 		};
-	private static final Class<?>[] _deleteDiscussionMessageParameterTypes5 = new Class[] {
+	private static final Class<?>[] _deleteDiscussionMessageParameterTypes7 = new Class[] {
 			long.class, java.lang.String.class, long.class,
 			java.lang.String.class, long.class, long.class, long.class
 		};
-	private static final Class<?>[] _deleteMessageParameterTypes6 = new Class[] {
+	private static final Class<?>[] _deleteMessageParameterTypes8 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _deleteMessageAttachmentsParameterTypes7 = new Class[] {
+	private static final Class<?>[] _deleteMessageAttachmentsParameterTypes9 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _getCategoryMessagesParameterTypes8 = new Class[] {
+	private static final Class<?>[] _getCategoryMessagesParameterTypes10 = new Class[] {
 			long.class, long.class, int.class, int.class, int.class
 		};
-	private static final Class<?>[] _getCategoryMessagesCountParameterTypes9 = new Class[] {
+	private static final Class<?>[] _getCategoryMessagesCountParameterTypes11 = new Class[] {
 			long.class, long.class, int.class
 		};
-	private static final Class<?>[] _getCategoryMessagesRSSParameterTypes10 = new Class[] {
+	private static final Class<?>[] _getCategoryMessagesRSSParameterTypes12 = new Class[] {
 			long.class, long.class, int.class, int.class, java.lang.String.class,
 			double.class, java.lang.String.class, java.lang.String.class,
 			java.lang.String.class, com.liferay.portal.theme.ThemeDisplay.class
 		};
-	private static final Class<?>[] _getCompanyMessagesRSSParameterTypes11 = new Class[] {
+	private static final Class<?>[] _getCompanyMessagesRSSParameterTypes13 = new Class[] {
 			long.class, int.class, int.class, java.lang.String.class,
 			double.class, java.lang.String.class, java.lang.String.class,
 			java.lang.String.class, com.liferay.portal.theme.ThemeDisplay.class
 		};
-	private static final Class<?>[] _getGroupMessagesCountParameterTypes12 = new Class[] {
+	private static final Class<?>[] _getGroupMessagesCountParameterTypes14 = new Class[] {
 			long.class, int.class
 		};
-	private static final Class<?>[] _getGroupMessagesRSSParameterTypes13 = new Class[] {
+	private static final Class<?>[] _getGroupMessagesRSSParameterTypes15 = new Class[] {
 			long.class, int.class, int.class, java.lang.String.class,
 			double.class, java.lang.String.class, java.lang.String.class,
 			java.lang.String.class, com.liferay.portal.theme.ThemeDisplay.class
 		};
-	private static final Class<?>[] _getGroupMessagesRSSParameterTypes14 = new Class[] {
+	private static final Class<?>[] _getGroupMessagesRSSParameterTypes16 = new Class[] {
 			long.class, long.class, int.class, int.class, java.lang.String.class,
 			double.class, java.lang.String.class, java.lang.String.class,
 			java.lang.String.class, com.liferay.portal.theme.ThemeDisplay.class
 		};
-	private static final Class<?>[] _getMessageParameterTypes15 = new Class[] {
+	private static final Class<?>[] _getMessageParameterTypes17 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _getMessageDisplayParameterTypes16 = new Class[] {
+	private static final Class<?>[] _getMessageDisplayParameterTypes18 = new Class[] {
 			long.class, int.class, java.lang.String.class, boolean.class
 		};
-	private static final Class<?>[] _getThreadAnswersCountParameterTypes17 = new Class[] {
+	private static final Class<?>[] _getThreadAnswersCountParameterTypes19 = new Class[] {
 			long.class, long.class, long.class
 		};
-	private static final Class<?>[] _getThreadMessagesParameterTypes18 = new Class[] {
+	private static final Class<?>[] _getThreadMessagesParameterTypes20 = new Class[] {
 			long.class, long.class, long.class, int.class, int.class, int.class
 		};
-	private static final Class<?>[] _getThreadMessagesCountParameterTypes19 = new Class[] {
+	private static final Class<?>[] _getThreadMessagesCountParameterTypes21 = new Class[] {
 			long.class, long.class, long.class, int.class
 		};
-	private static final Class<?>[] _getThreadMessagesRSSParameterTypes20 = new Class[] {
+	private static final Class<?>[] _getThreadMessagesRSSParameterTypes22 = new Class[] {
 			long.class, int.class, int.class, java.lang.String.class,
 			double.class, java.lang.String.class, java.lang.String.class,
 			java.lang.String.class, com.liferay.portal.theme.ThemeDisplay.class
 		};
-	private static final Class<?>[] _restoreMessageAttachmentFromTrashParameterTypes21 =
+	private static final Class<?>[] _restoreMessageAttachmentFromTrashParameterTypes23 =
 		new Class[] { long.class, java.lang.String.class };
-	private static final Class<?>[] _subscribeMessageParameterTypes22 = new Class[] {
+	private static final Class<?>[] _subscribeMessageParameterTypes24 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _unsubscribeMessageParameterTypes23 = new Class[] {
+	private static final Class<?>[] _unsubscribeMessageParameterTypes25 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _updateAnswerParameterTypes24 = new Class[] {
+	private static final Class<?>[] _updateAnswerParameterTypes26 = new Class[] {
 			long.class, boolean.class, boolean.class
 		};
-	private static final Class<?>[] _updateDiscussionMessageParameterTypes25 = new Class[] {
+	private static final Class<?>[] _updateDiscussionMessageParameterTypes27 = new Class[] {
 			java.lang.String.class, long.class, java.lang.String.class,
 			long.class, long.class, long.class, java.lang.String.class,
 			java.lang.String.class,
 			com.liferay.portal.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateMessageParameterTypes26 = new Class[] {
+	private static final Class<?>[] _updateMessageParameterTypes28 = new Class[] {
 			long.class, java.lang.String.class, java.lang.String.class,
 			java.util.List.class, java.util.List.class, double.class,
 			boolean.class, com.liferay.portal.service.ServiceContext.class

--- a/portal-impl/src/com/liferay/portlet/messageboards/service/impl/MBMessageLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/service/impl/MBMessageLocalServiceImpl.java
@@ -94,6 +94,9 @@ import com.liferay.portlet.social.model.SocialActivityConstants;
 import com.liferay.portlet.trash.util.TrashUtil;
 import com.liferay.util.SerializableUtil;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.InputStream;
 
 import java.util.ArrayList;
@@ -400,6 +403,19 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 	@Override
 	public MBMessage addMessage(
 			long userId, String userName, long groupId, long categoryId,
+			String subject, String body, String fileName, File file,
+			ServiceContext serviceContext)
+		throws FileNotFoundException, PortalException, SystemException {
+
+		return addMessage(
+			userId, userName, groupId, categoryId, subject, body,
+			MBMessageConstants.DEFAULT_FORMAT, fileName, file, false, 0.0,
+			false, serviceContext);
+	}
+
+	@Override
+	public MBMessage addMessage(
+			long userId, String userName, long groupId, long categoryId,
 			String subject, String body, String format,
 			List<ObjectValuePair<String, InputStream>> inputStreamOVPs,
 			boolean anonymous, double priority, boolean allowPingbacks,
@@ -413,6 +429,30 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 			userId, userName, groupId, categoryId, threadId, parentMessageId,
 			subject, body, format, inputStreamOVPs, anonymous, priority,
 			allowPingbacks, serviceContext);
+	}
+
+	@Override
+	public MBMessage addMessage(
+			long userId, String userName, long groupId, long categoryId,
+			String subject, String body, String format, String fileName,
+			File file, boolean anonymous, double priority,
+			boolean allowPingbacks, ServiceContext serviceContext)
+		throws FileNotFoundException, PortalException, SystemException {
+
+		List<ObjectValuePair<String, InputStream>> inputStreamOVPs =
+			new ArrayList<ObjectValuePair<String, InputStream>>(1);
+
+		InputStream inputStream = new FileInputStream(file);
+
+		ObjectValuePair<String, InputStream> inputStreamOVP =
+			new ObjectValuePair<String, InputStream>(fileName, inputStream);
+
+		inputStreamOVPs.add(inputStreamOVP);
+
+		return addMessage(
+			userId, userName, groupId, categoryId, 0, 0, subject, body, format,
+			inputStreamOVPs, anonymous, priority, allowPingbacks,
+			serviceContext);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/messageboards/service/impl/MBMessageServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/service/impl/MBMessageServiceImpl.java
@@ -58,6 +58,9 @@ import com.sun.syndication.feed.synd.SyndLink;
 import com.sun.syndication.feed.synd.SyndLinkImpl;
 import com.sun.syndication.io.FeedException;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.InputStream;
 
 import java.util.ArrayList;
@@ -114,6 +117,18 @@ public class MBMessageServiceImpl extends MBMessageServiceBaseImpl {
 	@Override
 	public MBMessage addMessage(
 			long groupId, long categoryId, String subject, String body,
+			String fileName, File file, ServiceContext serviceContext)
+		throws FileNotFoundException, PortalException, SystemException {
+
+		return addMessage(
+			groupId, categoryId, subject, body,
+			MBMessageConstants.DEFAULT_FORMAT, fileName, file, false,
+			MBThreadConstants.PRIORITY_NOT_GIVEN, false, serviceContext);
+	}
+
+	@Override
+	public MBMessage addMessage(
+			long groupId, long categoryId, String subject, String body,
 			String format,
 			List<ObjectValuePair<String, InputStream>> inputStreamOVPs,
 			boolean anonymous, double priority, boolean allowPingbacks,
@@ -142,6 +157,29 @@ public class MBMessageServiceImpl extends MBMessageServiceBaseImpl {
 			getGuestOrUserId(), null, groupId, categoryId, subject, body,
 			format, inputStreamOVPs, anonymous, priority, allowPingbacks,
 			serviceContext);
+	}
+
+	@Override
+	public MBMessage addMessage(
+			long groupId, long categoryId, String subject, String body,
+			String format, String fileName, File file, boolean anonymous,
+			double priority, boolean allowPingbacks,
+			ServiceContext serviceContext)
+		throws FileNotFoundException, PortalException, SystemException {
+
+		List<ObjectValuePair<String, InputStream>> inputStreamOVPs =
+			new ArrayList<ObjectValuePair<String, InputStream>>();
+
+		InputStream inputStream = new FileInputStream(file);
+
+		ObjectValuePair<String, InputStream> inputStreamOVP =
+			new ObjectValuePair<String, InputStream>(fileName, inputStream);
+
+		inputStreamOVPs.add(inputStreamOVP);
+
+		return addMessage(
+			groupId, categoryId, subject, body, format, inputStreamOVPs,
+			anonymous, priority, allowPingbacks, serviceContext);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/portalsettings/action/EditLDAPServerAction.java
+++ b/portal-impl/src/com/liferay/portlet/portalsettings/action/EditLDAPServerAction.java
@@ -261,7 +261,7 @@ public class EditLDAPServerAction extends PortletAction {
 		PropsKeys.LDAP_SECURITY_CREDENTIALS, PropsKeys.LDAP_SECURITY_PRINCIPAL,
 		PropsKeys.LDAP_SERVER_NAME, PropsKeys.LDAP_USER_CUSTOM_MAPPINGS,
 		PropsKeys.LDAP_USER_DEFAULT_OBJECT_CLASSES,
-		PropsKeys.LDAP_USER_MAPPINGS, PropsKeys.LDAP_USERS_DN
+		PropsKeys.LDAP_USER_MAPPINGS, PropsKeys.LDAP_USERS_DN, "ldap.server.type"
 	};
 
 }

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -164,6 +164,7 @@
     upgrade.processes.6201=${upgrade.processes.master}
     upgrade.processes.6202=${upgrade.processes.master}
     upgrade.processes.6203=${upgrade.processes.master}
+    upgrade.processes.6204=${upgrade.processes.master}
 
     #
     # If this property is specified with a list of classes, then the portal will

--- a/portal-service/src/com/liferay/portal/kernel/servlet/taglib/aui/ValidatorTag.java
+++ b/portal-service/src/com/liferay/portal/kernel/servlet/taglib/aui/ValidatorTag.java
@@ -29,4 +29,6 @@ public interface ValidatorTag {
 
 	public boolean isCustom();
 
+	public boolean isCustomValidatorRequired();
+
 }

--- a/portal-service/src/com/liferay/portal/kernel/util/ReleaseInfo.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/ReleaseInfo.java
@@ -93,6 +93,8 @@ public class ReleaseInfo {
 
 	public static final int RELEASE_6_2_4_BUILD_NUMBER = 6204;
 
+	public static final int RELEASE_6_2_5_BUILD_NUMBER = 6205;
+
 	public static final int RELEASE_6_2_10_BUILD_NUMBER = 6210;
 
 	public static final Date getBuildDate() {
@@ -144,13 +146,13 @@ public class ReleaseInfo {
 		return _VERSION;
 	}
 
-	private static final String _BUILD = "6204";
+	private static final String _BUILD = "6205";
 
 	private static final int _BUILD_NUMBER = GetterUtil.getInteger(_BUILD);
 
 	private static final String _CODE_NAME = "Newton";
 
-	private static final String _DATE = "November 25, 2015";
+	private static final String _DATE = "January 6, 2016";
 
 	private static final String _NAME = "Liferay Portal Community Edition";
 
@@ -164,9 +166,9 @@ public class ReleaseInfo {
 
 	private static final String _VENDOR = "Liferay, Inc.";
 
-	private static final String _VERSION = "6.2.4";
+	private static final String _VERSION = "6.2.5";
 
-	private static final String _VERSION_DISPLAY_NAME = "6.2 CE GA5";
+	private static final String _VERSION_DISPLAY_NAME = "6.2 CE GA6";
 
 	private static String _releaseInfo;
 	private static String _serverInfo;

--- a/portal-service/src/com/liferay/portlet/messageboards/service/MBMessageLocalService.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/service/MBMessageLocalService.java
@@ -334,12 +334,31 @@ public interface MBMessageLocalService extends BaseLocalService,
 	public com.liferay.portlet.messageboards.model.MBMessage addMessage(
 		long userId, java.lang.String userName, long groupId, long categoryId,
 		java.lang.String subject, java.lang.String body,
+		java.lang.String fileName, java.io.File file,
+		com.liferay.portal.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException,
+			java.io.FileNotFoundException;
+
+	public com.liferay.portlet.messageboards.model.MBMessage addMessage(
+		long userId, java.lang.String userName, long groupId, long categoryId,
+		java.lang.String subject, java.lang.String body,
 		java.lang.String format,
 		java.util.List<com.liferay.portal.kernel.util.ObjectValuePair<java.lang.String, java.io.InputStream>> inputStreamOVPs,
 		boolean anonymous, double priority, boolean allowPingbacks,
 		com.liferay.portal.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException;
+
+	public com.liferay.portlet.messageboards.model.MBMessage addMessage(
+		long userId, java.lang.String userName, long groupId, long categoryId,
+		java.lang.String subject, java.lang.String body,
+		java.lang.String format, java.lang.String fileName, java.io.File file,
+		boolean anonymous, double priority, boolean allowPingbacks,
+		com.liferay.portal.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException,
+			java.io.FileNotFoundException;
 
 	public com.liferay.portlet.messageboards.model.MBMessage addMessage(
 		long userId, java.lang.String userName, long categoryId,

--- a/portal-service/src/com/liferay/portlet/messageboards/service/MBMessageLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/service/MBMessageLocalServiceUtil.java
@@ -371,6 +371,19 @@ public class MBMessageLocalServiceUtil {
 	public static com.liferay.portlet.messageboards.model.MBMessage addMessage(
 		long userId, java.lang.String userName, long groupId, long categoryId,
 		java.lang.String subject, java.lang.String body,
+		java.lang.String fileName, java.io.File file,
+		com.liferay.portal.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException,
+			java.io.FileNotFoundException {
+		return getService()
+				   .addMessage(userId, userName, groupId, categoryId, subject,
+			body, fileName, file, serviceContext);
+	}
+
+	public static com.liferay.portlet.messageboards.model.MBMessage addMessage(
+		long userId, java.lang.String userName, long groupId, long categoryId,
+		java.lang.String subject, java.lang.String body,
 		java.lang.String format,
 		java.util.List<com.liferay.portal.kernel.util.ObjectValuePair<java.lang.String, java.io.InputStream>> inputStreamOVPs,
 		boolean anonymous, double priority, boolean allowPingbacks,
@@ -380,6 +393,21 @@ public class MBMessageLocalServiceUtil {
 		return getService()
 				   .addMessage(userId, userName, groupId, categoryId, subject,
 			body, format, inputStreamOVPs, anonymous, priority, allowPingbacks,
+			serviceContext);
+	}
+
+	public static com.liferay.portlet.messageboards.model.MBMessage addMessage(
+		long userId, java.lang.String userName, long groupId, long categoryId,
+		java.lang.String subject, java.lang.String body,
+		java.lang.String format, java.lang.String fileName, java.io.File file,
+		boolean anonymous, double priority, boolean allowPingbacks,
+		com.liferay.portal.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException,
+			java.io.FileNotFoundException {
+		return getService()
+				   .addMessage(userId, userName, groupId, categoryId, subject,
+			body, format, fileName, file, anonymous, priority, allowPingbacks,
 			serviceContext);
 	}
 

--- a/portal-service/src/com/liferay/portlet/messageboards/service/MBMessageLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/service/MBMessageLocalServiceWrapper.java
@@ -390,6 +390,19 @@ public class MBMessageLocalServiceWrapper implements MBMessageLocalService,
 	public com.liferay.portlet.messageboards.model.MBMessage addMessage(
 		long userId, java.lang.String userName, long groupId, long categoryId,
 		java.lang.String subject, java.lang.String body,
+		java.lang.String fileName, java.io.File file,
+		com.liferay.portal.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException,
+			java.io.FileNotFoundException {
+		return _mbMessageLocalService.addMessage(userId, userName, groupId,
+			categoryId, subject, body, fileName, file, serviceContext);
+	}
+
+	@Override
+	public com.liferay.portlet.messageboards.model.MBMessage addMessage(
+		long userId, java.lang.String userName, long groupId, long categoryId,
+		java.lang.String subject, java.lang.String body,
 		java.lang.String format,
 		java.util.List<com.liferay.portal.kernel.util.ObjectValuePair<java.lang.String, java.io.InputStream>> inputStreamOVPs,
 		boolean anonymous, double priority, boolean allowPingbacks,
@@ -398,6 +411,21 @@ public class MBMessageLocalServiceWrapper implements MBMessageLocalService,
 			com.liferay.portal.kernel.exception.SystemException {
 		return _mbMessageLocalService.addMessage(userId, userName, groupId,
 			categoryId, subject, body, format, inputStreamOVPs, anonymous,
+			priority, allowPingbacks, serviceContext);
+	}
+
+	@Override
+	public com.liferay.portlet.messageboards.model.MBMessage addMessage(
+		long userId, java.lang.String userName, long groupId, long categoryId,
+		java.lang.String subject, java.lang.String body,
+		java.lang.String format, java.lang.String fileName, java.io.File file,
+		boolean anonymous, double priority, boolean allowPingbacks,
+		com.liferay.portal.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException,
+			java.io.FileNotFoundException {
+		return _mbMessageLocalService.addMessage(userId, userName, groupId,
+			categoryId, subject, body, format, fileName, file, anonymous,
 			priority, allowPingbacks, serviceContext);
 	}
 

--- a/portal-service/src/com/liferay/portlet/messageboards/service/MBMessageService.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/service/MBMessageService.java
@@ -88,12 +88,30 @@ public interface MBMessageService extends BaseService {
 
 	public com.liferay.portlet.messageboards.model.MBMessage addMessage(
 		long groupId, long categoryId, java.lang.String subject,
+		java.lang.String body, java.lang.String fileName, java.io.File file,
+		com.liferay.portal.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException,
+			java.io.FileNotFoundException;
+
+	public com.liferay.portlet.messageboards.model.MBMessage addMessage(
+		long groupId, long categoryId, java.lang.String subject,
 		java.lang.String body, java.lang.String format,
 		java.util.List<com.liferay.portal.kernel.util.ObjectValuePair<java.lang.String, java.io.InputStream>> inputStreamOVPs,
 		boolean anonymous, double priority, boolean allowPingbacks,
 		com.liferay.portal.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException;
+
+	public com.liferay.portlet.messageboards.model.MBMessage addMessage(
+		long groupId, long categoryId, java.lang.String subject,
+		java.lang.String body, java.lang.String format,
+		java.lang.String fileName, java.io.File file, boolean anonymous,
+		double priority, boolean allowPingbacks,
+		com.liferay.portal.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException,
+			java.io.FileNotFoundException;
 
 	public com.liferay.portlet.messageboards.model.MBMessage addMessage(
 		long categoryId, java.lang.String subject, java.lang.String body,

--- a/portal-service/src/com/liferay/portlet/messageboards/service/MBMessageServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/service/MBMessageServiceUtil.java
@@ -95,6 +95,18 @@ public class MBMessageServiceUtil {
 
 	public static com.liferay.portlet.messageboards.model.MBMessage addMessage(
 		long groupId, long categoryId, java.lang.String subject,
+		java.lang.String body, java.lang.String fileName, java.io.File file,
+		com.liferay.portal.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException,
+			java.io.FileNotFoundException {
+		return getService()
+				   .addMessage(groupId, categoryId, subject, body, fileName,
+			file, serviceContext);
+	}
+
+	public static com.liferay.portlet.messageboards.model.MBMessage addMessage(
+		long groupId, long categoryId, java.lang.String subject,
 		java.lang.String body, java.lang.String format,
 		java.util.List<com.liferay.portal.kernel.util.ObjectValuePair<java.lang.String, java.io.InputStream>> inputStreamOVPs,
 		boolean anonymous, double priority, boolean allowPingbacks,
@@ -104,6 +116,20 @@ public class MBMessageServiceUtil {
 		return getService()
 				   .addMessage(groupId, categoryId, subject, body, format,
 			inputStreamOVPs, anonymous, priority, allowPingbacks, serviceContext);
+	}
+
+	public static com.liferay.portlet.messageboards.model.MBMessage addMessage(
+		long groupId, long categoryId, java.lang.String subject,
+		java.lang.String body, java.lang.String format,
+		java.lang.String fileName, java.io.File file, boolean anonymous,
+		double priority, boolean allowPingbacks,
+		com.liferay.portal.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException,
+			java.io.FileNotFoundException {
+		return getService()
+				   .addMessage(groupId, categoryId, subject, body, format,
+			fileName, file, anonymous, priority, allowPingbacks, serviceContext);
 	}
 
 	public static com.liferay.portlet.messageboards.model.MBMessage addMessage(

--- a/portal-service/src/com/liferay/portlet/messageboards/service/MBMessageServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/service/MBMessageServiceWrapper.java
@@ -89,6 +89,18 @@ public class MBMessageServiceWrapper implements MBMessageService,
 	@Override
 	public com.liferay.portlet.messageboards.model.MBMessage addMessage(
 		long groupId, long categoryId, java.lang.String subject,
+		java.lang.String body, java.lang.String fileName, java.io.File file,
+		com.liferay.portal.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException,
+			java.io.FileNotFoundException {
+		return _mbMessageService.addMessage(groupId, categoryId, subject, body,
+			fileName, file, serviceContext);
+	}
+
+	@Override
+	public com.liferay.portlet.messageboards.model.MBMessage addMessage(
+		long groupId, long categoryId, java.lang.String subject,
 		java.lang.String body, java.lang.String format,
 		java.util.List<com.liferay.portal.kernel.util.ObjectValuePair<java.lang.String, java.io.InputStream>> inputStreamOVPs,
 		boolean anonymous, double priority, boolean allowPingbacks,
@@ -97,6 +109,21 @@ public class MBMessageServiceWrapper implements MBMessageService,
 			com.liferay.portal.kernel.exception.SystemException {
 		return _mbMessageService.addMessage(groupId, categoryId, subject, body,
 			format, inputStreamOVPs, anonymous, priority, allowPingbacks,
+			serviceContext);
+	}
+
+	@Override
+	public com.liferay.portlet.messageboards.model.MBMessage addMessage(
+		long groupId, long categoryId, java.lang.String subject,
+		java.lang.String body, java.lang.String format,
+		java.lang.String fileName, java.io.File file, boolean anonymous,
+		double priority, boolean allowPingbacks,
+		com.liferay.portal.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException,
+			java.io.FileNotFoundException {
+		return _mbMessageService.addMessage(groupId, categoryId, subject, body,
+			format, fileName, file, anonymous, priority, allowPingbacks,
 			serviceContext);
 	}
 

--- a/portal-web/docroot/html/js/liferay/form.js
+++ b/portal-web/docroot/html/js/liferay/form.js
@@ -176,7 +176,7 @@ AUI.add(
 						fieldRules[validatorName] = value;
 
 						if (rule.custom) {
-							fieldRules.custom = rule.custom;
+							fieldRules.custom = rule.customValidatorRequired;
 
 							DEFAULTS_FORM_VALIDATOR.RULES[validatorName] = rule.body;
 						}

--- a/portal-web/docroot/html/js/liferay/liferay.js
+++ b/portal-web/docroot/html/js/liferay/liferay.js
@@ -88,9 +88,11 @@ Liferay = window.Liferay || {};
 
 				var ioConfig = payload.io || {};
 
+				var form = args[1] || {};
+
 				delete payload.io;
 
-				if (!(ioConfig.on && ioConfig.on.success)) {
+				if (!(ioConfig.on && (ioConfig.on.success || ioConfig.on.complete))) {
 					var callbacks = A.Array.filter(args, Lang.isFunction);
 
 					var callbackSuccess = callbacks[0];
@@ -101,6 +103,24 @@ Liferay = window.Liferay || {};
 					}
 
 					A.namespace.call(ioConfig, 'on');
+
+					if (form.enctype == 'multipart/form-data') {
+						ioConfig.on.complete = function(event) {
+							 var responseText = event.details[1].responseText;
+							 var responseData = JSON.parse(responseText);
+
+							 if ((responseData !== null) && !owns(responseData, 'exception')) {
+								 if (callbackSuccess) {
+								 	callbackSuccess.call(this, responseData);
+								 }
+							 }
+							 else if (callbackException) {
+								 var exception = responseData ? responseData.exception : 'The server returned an empty response';
+
+								 callbackException.call(this, exception, responseData);
+							 }
+						 };
+					}
 
 					ioConfig.on.success = function(event) {
 						var responseData = this.get('responseData');
@@ -138,6 +158,10 @@ Liferay = window.Liferay || {};
 					A.namespace.call(ioConfig, 'form');
 
 					ioConfig.form.id = form._node || form;
+
+					if (ioConfig.form.id.enctype == 'multipart/form-data') {
+						ioConfig.form.upload = true;
+					}
 				}
 			},
 

--- a/portal-web/docroot/html/portlet/document_library/edit_file_entry.jsp
+++ b/portal-web/docroot/html/portlet/document_library/edit_file_entry.jsp
@@ -312,17 +312,19 @@ if ((checkedOut || pending) && !PropsValues.DL_FILE_ENTRY_DRAFTS_ENABLED) {
 			</c:if>
 		</div>
 
-		<div class="alert alert-error hide" id="<portlet:namespace />fileTitleError">
-			<liferay-ui:message key="you-must-specify-a-file-or-a-title" />
-		</div>
-
 		<aui:input autoFocus="<%= windowState.equals(WindowState.MAXIMIZED) %>" name="file" onChange='<%= renderResponse.getNamespace() + "validateTitle();" %>' style="width: auto;" type="file">
 			<aui:validator name="acceptFiles">
 				'<%= StringUtil.merge(PrefsPropsUtil.getStringArray(PropsKeys.DL_FILE_EXTENSIONS, StringPool.COMMA)) %>'
 			</aui:validator>
 		</aui:input>
 
-		<aui:input name="title" />
+		<aui:input name="title">
+			<aui:validator errorMessage="you-must-specify-a-file-or-a-title" name="required">
+				function() {
+					return !A.one('#<portlet:namespace />file').val();
+				}
+			</aui:validator>
+		</aui:input>
 
 		<c:if test="<%= ((folder == null) || folder.isSupportsMetadata()) %>">
 			<aui:input name="description" />
@@ -521,38 +523,19 @@ if ((checkedOut || pending) && !PropsValues.DL_FILE_ENTRY_DRAFTS_ENABLED) {
 	}
 
 	function <portlet:namespace />saveFileEntry(draft) {
-		var className = 'alert alert-danger';
+			var fileValue = document.<portlet:namespace />fm.<portlet:namespace />file.value;
 
-		var fileTitleErrorNode = document.getElementById('<portlet:namespace />fileTitleError');
-
-		var form = document.<portlet:namespace />fm;
-
-		if (form && fileTitleErrorNode) {
-			fileTitleErrorNode.className = className + ' hide';
-
-			var fileValue = form.<portlet:namespace />file.value;
-
-			var hasFieldValue = !!(fileValue || form.<portlet:namespace />title.value);
-
-			if (hasFieldValue) {
-				if (fileValue) {
-					<%= HtmlUtil.escape(uploadProgressId) %>.startProgress();
-				}
-
-				form.<portlet:namespace /><%= Constants.CMD %>.value = '<%= (fileEntry == null) ? Constants.ADD : Constants.UPDATE %>';
-
-				if (draft) {
-					form.<portlet:namespace />workflowAction.value = '<%= WorkflowConstants.ACTION_SAVE_DRAFT %>';
-				}
-
-				submitForm(form);
+			if (fileValue) {
+				<%= HtmlUtil.escape(uploadProgressId) %>.startProgress();
 			}
-			else {
-				fileTitleErrorNode.className = className + ' show';
 
-				window.location.hash = '<portlet:namespace />fileTitleError';
+			document.<portlet:namespace />fm.<portlet:namespace /><%= Constants.CMD %>.value = '<%= (fileEntry == null) ? Constants.ADD : Constants.UPDATE %>';
+
+			if (draft) {
+				document.<portlet:namespace />fm.<portlet:namespace />workflowAction.value = '<%= WorkflowConstants.ACTION_SAVE_DRAFT %>';
 			}
-		}
+
+			submitForm(document.<portlet:namespace />fm);
 	}
 
 	function <portlet:namespace />validateTitle() {

--- a/portal-web/docroot/html/portlet/portal_settings/authentication/ldap.jsp
+++ b/portal-web/docroot/html/portlet/portal_settings/authentication/ldap.jsp
@@ -42,6 +42,7 @@ if (ldapAuthEnabled && (ldapServerIds.length <= 0) && Validator.isNull(PrefsProp
 	String ldapGroupDefaultObjectClasses = ParamUtil.getString(request, "settings--" + PropsKeys.LDAP_GROUP_DEFAULT_OBJECT_CLASSES + "--", PrefsPropsUtil.getString(company.getCompanyId(), PropsKeys.LDAP_GROUP_DEFAULT_OBJECT_CLASSES));
 	String ldapUserMappings = ParamUtil.getString(request, "settings--" + PropsKeys.LDAP_USER_MAPPINGS + "--", PrefsPropsUtil.getString(company.getCompanyId(), PropsKeys.LDAP_USER_MAPPINGS));
 	String ldapGroupMappings = ParamUtil.getString(request, "settings--" + PropsKeys.LDAP_GROUP_MAPPINGS + "--", PrefsPropsUtil.getString(company.getCompanyId(), PropsKeys.LDAP_GROUP_MAPPINGS));
+	String ldapType = ParamUtil.getString(request, "settings--" + "ldap.server.type" + "--", PrefsPropsUtil.getString(company.getCompanyId(), "ldap.server.type"));
 
 	if (Validator.isNotNull(ldapBaseProviderUrl)) {
 		long ldapServerId = CounterLocalServiceUtil.increment();
@@ -66,11 +67,13 @@ if (ldapAuthEnabled && (ldapServerIds.length <= 0) && Validator.isNull(PrefsProp
 		properties.put(PropsKeys.LDAP_GROUP_DEFAULT_OBJECT_CLASSES + postfix, ldapGroupDefaultObjectClasses);
 		properties.put(PropsKeys.LDAP_USER_MAPPINGS + postfix, ldapUserMappings);
 		properties.put(PropsKeys.LDAP_GROUP_MAPPINGS + postfix, ldapGroupMappings);
+		properties.put("ldap.server.type" + postfix, ldapServerName);
 		properties.put("ldap.server.ids", StringUtil.merge(ldapServerIds));
 
 		List<String> keys = new ArrayList<String>();
 
 		keys.add("ldap.server.name");
+		keys.add("ldap.server.type");
 		keys.add(PropsKeys.LDAP_BASE_PROVIDER_URL);
 		keys.add(PropsKeys.LDAP_BASE_DN);
 		keys.add(PropsKeys.LDAP_SECURITY_PRINCIPAL);

--- a/portal-web/docroot/html/portlet/portal_settings/edit_ldap_server.jsp
+++ b/portal-web/docroot/html/portlet/portal_settings/edit_ldap_server.jsp
@@ -25,9 +25,11 @@ long ldapServerId = ParamUtil.getLong(request, "ldapServerId", 0);
 String postfix = LDAPSettingsUtil.getPropertyPostfix(ldapServerId);
 
 String ldapServerName = PrefsPropsUtil.getString(company.getCompanyId(), "ldap.server.name" + postfix, StringPool.BLANK);
+String ldapServerType = PrefsPropsUtil.getString(company.getCompanyId(), "ldap.server.type" + postfix, StringPool.BLANK);
 String ldapBaseProviderUrl = PrefsPropsUtil.getString(company.getCompanyId(), PropsKeys.LDAP_BASE_PROVIDER_URL + postfix);
 String ldapBaseDN = PrefsPropsUtil.getString(company.getCompanyId(), PropsKeys.LDAP_BASE_DN + postfix);
 String ldapSecurityPrincipal = PrefsPropsUtil.getString(company.getCompanyId(), PropsKeys.LDAP_SECURITY_PRINCIPAL + postfix);
+pageContext.setAttribute("ldapServerType", ldapServerType);
 
 String ldapSecurityCredentials = PrefsPropsUtil.getString(company.getCompanyId(), PropsKeys.LDAP_SECURITY_CREDENTIALS + postfix);
 
@@ -178,14 +180,13 @@ for (int i = 0 ; i < groupMappingArray.length ; i++) {
 
 	<aui:fieldset>
 		<aui:field-wrapper>
-			<aui:input label="Apache Directory Server" name="defaultLdap" type="radio" value="apache" />
-			<aui:input label="Fedora Directory Server" name="defaultLdap" type="radio" value="fedora" />
-			<aui:input label="Microsoft Active Directory Server" name="defaultLdap" type="radio" value="microsoft" />
-			<aui:input label="Novell eDirectory" name="defaultLdap" type="radio" value="novell" />
-			<aui:input label="OpenLDAP" name="defaultLdap" type="radio" value="open" />
-			<aui:input label="other-directory-server" name="defaultLdap" type="radio" value="other" />
+			<aui:input label="Apache Directory Server" name='<%= "settings--ldap.server.type" + postfix + "--" %>' type="radio" value="apache" checked="${ldapServerType eq 'apache'}"/>
+			<aui:input label="Fedora Directory Server" name='<%= "settings--ldap.server.type" + postfix + "--" %>' type="radio" value="fedora" checked="${ldapServerType eq 'fedora'}"/>
+			<aui:input label="Microsoft Active Directory Server" name='<%= "settings--ldap.server.type" + postfix + "--" %>' type="radio" value="microsoft" checked="${ldapServerType eq 'microsoft'}"/>
+			<aui:input label="Novell eDirectory" name='<%= "settings--ldap.server.type" + postfix + "--" %>' type="radio" value="novell" checked="${ldapServerType eq 'novell'}"/>
+			<aui:input label="OpenLDAP" name='<%= "settings--ldap.server.type" + postfix + "--" %>' type="radio" value="open" checked="${ldapServerType eq 'open'}"/>
+			<aui:input label="other-directory-server" name='<%= "settings--ldap.server.type" + postfix + "--" %>' type="radio" value="other" checked="${ldapServerType eq 'other'}"/>
 		</aui:field-wrapper>
-
 		<aui:button-row>
 			<aui:button onClick='<%= renderResponse.getNamespace() + "updateDefaultLdap();" %>' value="reset-values" />
 		</aui:button-row>
@@ -448,7 +449,7 @@ for (int i = 0 ; i < groupMappingArray.length ; i++) {
 			var exportMappingGroupDefaultObjectClass = "";
 
 			if (!ldapType) {
-				A.all(document.<portlet:namespace />fm.<portlet:namespace />defaultLdap).some(
+				A.all(document.<portlet:namespace />fm['<portlet:namespace />settings--ldap.server.type<%= postfix %>--']).some(
 					function(item, index, collection) {
 						var checked = item.get('checked');
 

--- a/portal-web/docroot/html/portlet/sites_admin/site/site_url.jsp
+++ b/portal-web/docroot/html/portlet/sites_admin/site/site_url.jsp
@@ -113,7 +113,7 @@ String privateVirtualHost = ParamUtil.getString(request, "privateVirtualHost", B
 	<aui:input label="public-pages" name="publicVirtualHost" type="text" value="<%= publicVirtualHost %>" />
 
 	<aui:input label="private-pages" name="privateVirtualHost" type="text" value="<%= privateVirtualHost %>">
-		<aui:validator errorMessage="please-enter-a-unique-virtual-host" name="custom">
+		<aui:validator customValidatorRequired="<%= Boolean.FALSE %>"  errorMessage="please-enter-a-unique-virtual-host" name="custom">
 			function(val, fieldNode, ruleValue) {
 				return (val != A.one('#<portlet:namespace />publicVirtualHost').val());
 			}
@@ -137,7 +137,7 @@ String privateVirtualHost = ParamUtil.getString(request, "privateVirtualHost", B
 		%>
 
 		<aui:input label="staging-private-pages" name="stagingPrivateVirtualHost" type="text" value="<%= stagingPrivateVirtualHost %>">
-			<aui:validator errorMessage="please-enter-a-unique-virtual-host" name="custom">
+			<aui:validator customValidatorRequired="<%= Boolean.FALSE %>" errorMessage="please-enter-a-unique-virtual-host" name="custom">
 				function(val, fieldNode, ruleValue) {
 					return (val != A.one('#<portlet:namespace />stagingPublicVirtualHost').val());
 				}

--- a/portal-web/docroot/html/taglib/aui/form/end.jsp
+++ b/portal-web/docroot/html/taglib/aui/form/end.jsp
@@ -43,6 +43,7 @@
 							{
 								body: <%= validatorTag.getBody() %>,
 								custom: <%= validatorTag.isCustom() %>,
+								customValidatorRequired: <%= validatorTag.isCustomValidatorRequired() %>,
 								errorMessage: '<%= UnicodeLanguageUtil.get(pageContext, validatorTag.getErrorMessage()) %>',
 								fieldName: '<%= namespace + HtmlUtil.escapeJS(fieldName) %>',
 								validatorName: '<%= validatorTag.getName() %>'

--- a/portal-web/docroot/html/taglib/ui/input_date/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_date/page.jsp
@@ -77,7 +77,7 @@ Format format = FastDateFormatFactoryUtil.getSimpleDateFormat(simpleDateFormatPa
 		</c:when>
 		<c:otherwise>
 			<aui:input disabled="<%= disabled %>" id="<%= HtmlUtil.getAUICompatibleId(name) %>" label="" name="<%= name %>" placeholder="<%= StringUtil.toLowerCase(simpleDateFormatPattern) %>" title="" type="text" value="<%= nullable ? StringPool.BLANK : format.format(calendar.getTime()) %>" wrappedField="<%= true %>">
-				<aui:validator errorMessage="please-enter-a-valid-date" name="custom">
+				<aui:validator customValidatorRequired="<%= Boolean.FALSE %>" errorMessage="please-enter-a-valid-date" name="custom">
 					function(val) {
 						return AUI().use('aui-datatype-date-parse').Parsers.date('<%= mask %>', val);
 					}

--- a/util-taglib/src/META-INF/aui.tld
+++ b/util-taglib/src/META-INF/aui.tld
@@ -2475,6 +2475,13 @@
 		<tag-class>com.liferay.taglib.aui.ValidatorTagImpl</tag-class>
 		<body-content>JSP</body-content>
 		<attribute>
+			<description><![CDATA[Sets whether custom validator rules force a field to be required. The default value is <code>true</code>.]]></description>
+			<name>customValidatorRequired</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+			<type>boolean</type>
+		</attribute>
+		<attribute>
 			<description><![CDATA[Sets a custom error message to replace the default validation error message.]]></description>
 			<name>errorMessage</name>
 			<required>false</required>

--- a/util-taglib/src/com/liferay/taglib/aui/InputTag.java
+++ b/util-taglib/src/com/liferay/taglib/aui/InputTag.java
@@ -87,10 +87,12 @@ public class InputTag extends BaseInputTag {
 			String validatorErrorMessage = (String)modelValidator.getObject(2);
 			String validatorValue = (String)modelValidator.getObject(3);
 			boolean customValidator = (Boolean)modelValidator.getObject(4);
+			boolean customValidatorRequired = (Boolean)modelValidator.getObject(
+				5);
 
 			ValidatorTag validatorTag = new ValidatorTagImpl(
 				validatorName, validatorErrorMessage, validatorValue,
-				customValidator);
+				customValidator, customValidatorRequired);
 
 			addValidatorTag(validatorName, validatorTag);
 		}

--- a/util-taglib/src/com/liferay/taglib/aui/ValidatorTagImpl.java
+++ b/util-taglib/src/com/liferay/taglib/aui/ValidatorTagImpl.java
@@ -37,11 +37,19 @@ public class ValidatorTagImpl
 	public ValidatorTagImpl(
 		String name, String errorMessage, String body, boolean custom) {
 
+		this(name, errorMessage, body, custom, true);
+	}
+
+	public ValidatorTagImpl(
+		String name, String errorMessage, String body, boolean custom,
+		boolean customValidatorRequired) {
+
 		setName(name);
 		setErrorMessage(errorMessage);
 
 		_body = body;
 		_custom = custom;
+		_customValidatorRequired = customValidatorRequired;
 	}
 
 	@Override
@@ -50,6 +58,7 @@ public class ValidatorTagImpl
 
 		_body = null;
 		_custom = false;
+		_customValidatorRequired = true;
 	}
 
 	@Override
@@ -77,7 +86,7 @@ public class ValidatorTagImpl
 		}
 
 		ValidatorTag validatorTag = new ValidatorTagImpl(
-			name, getErrorMessage(), _body, _custom);
+			name, getErrorMessage(), _body, _custom, _customValidatorRequired);
 
 		inputTag.addValidatorTag(name, validatorTag);
 
@@ -109,6 +118,15 @@ public class ValidatorTagImpl
 		return _custom;
 	}
 
+	@Override
+	public boolean isCustomValidatorRequired() {
+		return _customValidatorRequired;
+	}
+
+	public void setCustomValidatorRequired(boolean customValidatorRequired) {
+		_customValidatorRequired = customValidatorRequired;
+	}
+
 	public void setBody(String body) {
 		_body = body;
 	}
@@ -126,5 +144,6 @@ public class ValidatorTagImpl
 
 	private String _body;
 	private boolean _custom;
+	private boolean _customValidatorRequired = true;
 
 }

--- a/util-taglib/src/com/liferay/taglib/aui/base/BaseValidatorTagImpl.java
+++ b/util-taglib/src/com/liferay/taglib/aui/base/BaseValidatorTagImpl.java
@@ -23,11 +23,15 @@ import javax.servlet.jsp.JspException;
  * @author Julio Camarero
  * @generated
  */
-public class BaseValidatorTagImpl extends com.liferay.portal.kernel.servlet.taglib.BaseBodyTagSupport {
+public abstract class BaseValidatorTagImpl extends com.liferay.portal.kernel.servlet.taglib.BaseBodyTagSupport {
 
 	@Override
 	public int doStartTag() throws JspException {
 		return super.doStartTag();
+	}
+
+	public boolean getCustomValidatorRequired() {
+		return _customValidatorRequired;
 	}
 
 	public java.lang.String getErrorMessage() {
@@ -36,6 +40,10 @@ public class BaseValidatorTagImpl extends com.liferay.portal.kernel.servlet.tagl
 
 	public java.lang.String getName() {
 		return _name;
+	}
+
+	public void setCustomValidatorRequired(boolean customValidatorRequired) {
+		_customValidatorRequired = customValidatorRequired;
 	}
 
 	public void setErrorMessage(java.lang.String errorMessage) {
@@ -47,6 +55,7 @@ public class BaseValidatorTagImpl extends com.liferay.portal.kernel.servlet.tagl
 	}
 
 	protected void cleanUp() {
+		_customValidatorRequired = false;
 		_errorMessage = null;
 		_name = null;
 	}
@@ -58,6 +67,7 @@ public class BaseValidatorTagImpl extends com.liferay.portal.kernel.servlet.tagl
 	private static final String _PAGE =
 		"/html/taglib/aui/validator/page.jsp";
 
+	private boolean _customValidatorRequired = false;
 	private java.lang.String _errorMessage = null;
 	private java.lang.String _name = null;
 

--- a/util-taglib/src/com/liferay/taglib/liferay-aui.xml
+++ b/util-taglib/src/com/liferay/taglib/liferay-aui.xml
@@ -1376,6 +1376,12 @@
 		<description>Creates a component to validate input fields.</description>
 		<attributes>
 			<attribute>
+				<description>Sets whether custom validator rules force a field to be required. The default value is <![CDATA[<code>true</code>]]>.</description>
+				<name>customValidatorRequired</name>
+				<inputType>boolean</inputType>
+				<outputType>boolean</outputType>
+			</attribute>
+			<attribute>
 				<description>Sets a custom error message to replace the default validation error message.</description>
 				<name>errorMessage</name>
 				<inputType>java.lang.String</inputType>


### PR DESCRIPTION
Fixed the code to retain LDAP type selection as-is while Editing earlier saved settings for LDAP..

Environment Details:
Liferay Portal : 6.2.x
Tomcat : 7.0.62
Databse : MySql 5.6
Browsers : IE/Mozilla Firefox/Google Chrome

The issue of , Post save from edit LDAP configuration page, the page was being redirected to display setting, mentioned in the bug description is not reproducible.
Here are the steps performed -

Add the following entry in portal-ext.properties: locales=en_US (As per the steps reported in JIRA)
Restart the server.
Login as Administration and navigate to Control Panel->Portal Settings ->Authentication tab
Edit any Existing LDAP configuration and click on save.
Post save, the page is redirecting to the Authentication Tab -> General category